### PR TITLE
Extend timeparse module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 This is a tool to quickly create pagerduty overrides from the command line.
 
 
+
 ## usage: create
+
 
 Create overrides for the current day:
 
@@ -22,12 +24,17 @@ Create an override for yourself:
 pd-quick-override create --me --at 'today, 4:30pm-5:30pm'
 ```
 
+
 Specify a timezone (`create` will default to your local timezone)
+
 
 ```
 pd-quick-override create --time-zone 'Europe/Paris --at 'today, 4:00pm-5:00pm'
 ```
 
+
 ## usage: reset-api-key
 
 Todo
+
+

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 This is a tool to quickly create pagerduty overrides from the command line.
 
 
-
 ## usage: create
-
 
 Create overrides for the current day:
 
@@ -24,17 +22,12 @@ Create an override for yourself:
 pd-quick-override create --me --at 'today, 4:30pm-5:30pm'
 ```
 
-
 Specify a timezone (`create` will default to your local timezone)
-
 
 ```
 pd-quick-override create --time-zone 'Europe/Paris --at 'today, 4:00pm-5:00pm'
 ```
 
-
 ## usage: reset-api-key
 
 Todo
-
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ async fn main() {
             tz.timestamp_opt(now, 0).unwrap();
             let (from, to) = timeparse::parse(&tz.timestamp_opt(now, 0).unwrap(), at.as_str())
                 .unwrap_or_else(|e| {
-                    println!("cannot parse: {}", e);
+                    println!("cannot parse: {:?}", e);
                     std::process::exit(1);
                 });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ enum Commands {
     Create {
         #[arg(short, long)]
         at: String,
-        
+
         #[arg(short, long)]
         me: bool,
 
@@ -80,14 +80,17 @@ async fn main() {
             let selected_schedule =
                 fuzzyselect::select(&schedules_by_name).expect("could not read it");
 
-            println!("will create override on user {selected_user} for schedule {selected_schedule} from {from} to {to}, confirm to continue");
+            println!("will create override on user {selected_user} for schedule {selected_schedule} from {from} to {to}, confirm to continue.");
             if confirm() {
                 client.create_schedule_override(selected_user, selected_schedule, from, to).await.expect("could not create override");
                 println!("Override created! Good luck! ")
             }
         },
-        Commands::ResetApiKey {} => { 
-            todo!();
+        Commands::ResetApiKey {} => {
+            println!("Will clear pagerduty API key from system keychain. This is not reversable. Confirm to continue.");
+            if confirm() {
+                todo!("not implemented");
+            }
         },
     }
 }

--- a/src/timeparse.rs
+++ b/src/timeparse.rs
@@ -52,8 +52,10 @@ fn parse_single_time(base: DateTime<Tz>, timestr: &str) -> Result<DateTime<Tz>, 
         source: Some(String::from(timestr)),
     };
 
+    let lowered = timestr.to_lowercase();
+
     let r = regex::Regex::new(r"(?P<h>\d\d?)(:(?P<m>\d\d))?\s*(?P<me>am|pm)").expect("could not compile");
-    let caps = r.captures(timestr).ok_or(error)?;
+    let caps = r.captures(lowered.as_str()).ok_or(error)?;
 
     let mut hour: u32 = caps.name("h").unwrap().as_str().parse().unwrap();
 
@@ -177,9 +179,15 @@ mod testing {
             Utc.with_ymd_and_hms(2023, 2, 11, 5, 0, 0),
             Utc.with_ymd_and_hms(2023, 2, 11, 6, 0, 0));
 
+
         run_test("today, 12:00am-01:30am",
             Utc.with_ymd_and_hms(2023, 2, 11, 5, 0, 0),
             Utc.with_ymd_and_hms(2023, 2, 11, 6, 30, 0));
+
+        // weird capitalization
+        run_test("today, 11Am-12PM",
+            Utc.with_ymd_and_hms(2023, 2, 11, 16, 0, 0),
+            Utc.with_ymd_and_hms(2023, 2, 11, 17, 0, 0));
 
     }
 }

--- a/src/timeparse.rs
+++ b/src/timeparse.rs
@@ -50,16 +50,16 @@ pub fn parse(
 ) -> Result<(DateTime<Tz>, DateTime<Tz>), ParseError> {
     let lowered_string = range_str.to_lowercase();
 
-    if let Ok((start, end)) = parse_single_multi_day_range(now.clone(), &lowered_string) {
+    if let Ok((start, end)) = parse_single_multi_day_range(now, &lowered_string) {
         return Ok((start, end));
     }
 
-    parse_single_day_range(*now, &lowered_string)
+    parse_single_day_range(now, &lowered_string)
 }
 
 
 fn parse_single_day_range(
-    now: DateTime<Tz>,
+    now: &DateTime<Tz>,
     source: &str,
 )  -> Result<(DateTime<Tz>, DateTime<Tz>), ParseError> {
     let date_parse = parse_date(now, source)?;
@@ -71,7 +71,7 @@ fn parse_single_day_range(
 }
 
 fn parse_single_multi_day_range(
-    now: DateTime<Tz>,
+    now: &DateTime<Tz>,
     source: &str,
 )  -> Result<(DateTime<Tz>, DateTime<Tz>), ParseError> {
     let start_date_parse = parse_date(now, source)?;
@@ -82,7 +82,7 @@ fn parse_single_multi_day_range(
     Ok((start_time_parse.result, end_time_parse.result))
 }
 
-fn parse_date(now: DateTime<Tz>, source: &str) -> Result<Parse<DateTime<Tz>>, ParseError> {
+fn parse_date<'a>(now: &DateTime<Tz>, source: &'a str) -> Result<Parse<'a, DateTime<Tz>>, ParseError> {
     if let Ok(parse) = parse_literal(source, "today") {
         let today = now.duration_trunc(Duration::days(1)).unwrap();
         return Ok(Parse { rest: parse.rest, result: today });
@@ -101,7 +101,7 @@ fn parse_date(now: DateTime<Tz>, source: &str) -> Result<Parse<DateTime<Tz>>, Pa
     Err(ParseError::UnrecognizedDate(String::from(source)))
 }
 
-fn parse_month_day_date(now: DateTime<Tz>, source: &str) -> Result<Parse<DateTime<Tz>>, ParseError> {
+fn parse_month_day_date<'a>(now: &DateTime<Tz>, source: &'a str) -> Result<Parse<'a, DateTime<Tz>>, ParseError> {
     let month_parse = parse_number(source)?;
     let slash_parse = parse_literal(month_parse.rest, "/")?;
     let date_parse = parse_number(slash_parse.rest)?;
@@ -291,8 +291,8 @@ mod testing {
 
         let tz: Tz = "America/New_York".parse().unwrap();
         let now = tz.with_ymd_and_hms(2023, 2, 11, 12, 0, 0).unwrap();
-        parse_date(now, "today").expect("expected to parse date");
-        parse_date(now, "10/30").expect("expected date to parse");
+        parse_date(&now, "today").expect("expected to parse date");
+        parse_date(&now, "10/30").expect("expected date to parse");
         parse_time(now, "10:30 am").expect("expected date to parse");
     }
 }

--- a/src/timeparse.rs
+++ b/src/timeparse.rs
@@ -36,7 +36,7 @@ pub fn parse(
 ) -> Result<(DateTime<Tz>, DateTime<Tz>), ParseError> {
     let lowered_string = range_str.to_lowercase();
 
-    return  parse_single_day_range(now.clone(), &lowered_string);
+    parse_single_day_range(*now, &lowered_string)
 }
 
 
@@ -44,7 +44,7 @@ fn parse_single_day_range(
     now: DateTime<Tz>,
     source: &str,
 )  -> Result<(DateTime<Tz>, DateTime<Tz>), ParseError> {
-    let date_parse = parse_date(now.clone(), &source)?;
+    let date_parse = parse_date(now, source)?;
     let comma_parse = parse_literal(date_parse.rest , ",")?;
     let start_time_parse = parse_time(date_parse.result, comma_parse.rest)?;
     let hyphen_parse = parse_literal(start_time_parse.rest, "-")?;
@@ -68,7 +68,7 @@ fn parse_date(now: DateTime<Tz>, source: &str) -> Result<Parse<DateTime<Tz>>, Pa
         return Ok(parse);
     }
 
-    return Err(ParseError::UnrecognizedDate(String::from(source)));
+    Err(ParseError::UnrecognizedDate(String::from(source)))
 }
 
 fn parse_month_day_date(now: DateTime<Tz>, source: &str) -> Result<Parse<DateTime<Tz>>, ParseError> {
@@ -121,7 +121,7 @@ fn parse_time(base: DateTime<Tz>, source: &str) -> Result<Parse<DateTime<Tz>>, P
         .with_minute(minute.unwrap_or(0))
         .unwrap();
 
-    return Ok(Parse { rest: rest, result: time });
+    Ok(Parse { rest, result: time })
 }
 
 fn parse_meridiem(source: &str) -> Result<Parse<Meridiem>, ParseError> {
@@ -144,7 +144,7 @@ fn parse_number<'a>(source: &'a str) -> Result<Parse<'a, u32>, ParseError> {
 
     let n = source[0..schars].parse::<u32>();
 
-    return Ok(Parse { rest: &source[schars..source.len()], result: n.unwrap() });
+    Ok(Parse { rest: &source[schars..source.len()], result: n.unwrap() })
 }
 
 fn parse_literal<'a>(source: &'a str, literal: &str) -> Result<Parse<'a, ()>, ParseError> {
@@ -193,7 +193,7 @@ mod testing {
         let run_test =
             |s: &str, from: LocalResult<DateTime<Utc>>, to: LocalResult<DateTime<Utc>>| {
                 let (parsed_from, parsed_to) =
-                    parse(&now, s).expect(format!("expected to parse {:?}", s).as_str());
+                    parse(&now, s).unwrap_or_else(|_| panic!("expected to parse {:?}", s));
                 assert_eq!(parsed_from.timestamp(), from.unwrap().timestamp());
                 assert_eq!(parsed_to.timestamp(), to.unwrap().timestamp());
             };

--- a/src/timeparse.rs
+++ b/src/timeparse.rs
@@ -90,10 +90,9 @@ fn parse_time(base: DateTime<Tz>, source: &str) -> Result<Parse<DateTime<Tz>>, P
     let hour_parse = parse_number(source)?;
     let mut rest = hour_parse.rest;
 
-    let colon_parse = parse_literal(rest, ":");
     let mut minute = Some(0);
-    if colon_parse.is_ok() {
-        rest = colon_parse.unwrap().rest;
+    if let Ok(colon_parse) = parse_literal(rest, ":"){
+        rest = colon_parse.rest;
         let minute_parse = parse_number(rest)?;
         
         minute = Some(minute_parse.result);
@@ -136,7 +135,7 @@ fn parse_meridiem(source: &str) -> Result<Parse<Meridiem>, ParseError> {
     Err(ParseError::IllegalMeridiem(String::from(source)))
 }
 
-fn parse_number<'a>(source: &'a str) -> Result<Parse<'a, u32>, ParseError> {
+fn parse_number(source: &str) -> Result<Parse<u32>, ParseError> {
     let schars = source.chars().take_while(|x| x.is_numeric()).count();
     if schars == 0 {
         return Err(ParseError::ExpectedNumber(source.to_string()));


### PR DESCRIPTION
* implement everything with parsercombinators
* use thiserror to be less verbose 
* implement single time ranges that span multiple days
* more docs
* more testing, including DST boundary testing  